### PR TITLE
Add ability to process class files with no annotations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+max_line_length = 100

--- a/README.md
+++ b/README.md
@@ -17,19 +17,14 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 Another use case could be to use Hypershard as a dependency in your project
 
 ```groovy
-implementation 'com.dropbox.mobile.hypershard:hypershard:1.0.0'
+implementation 'com.dropbox.mobile.hypershard:hypershard:x.y.z'
 ```
 
 
 # Usage
-The argument is a vararg, you can pass in as many directories as you want, separated by spaces
 ```
-java -jar hypershard-1.0.0.jar $annotation $path
-
-# @param annotation - test class annotation to look for e.g. UiTest
-# @param path - The location of the test classes to parse e.g. /path/to/tests
+java -jar hypershard-*.jar --help
 ```
-The output is a list of fully qualified tests separated by new lines.
 
 Here's an [example Python script](example/run_hypershard.py) that uses Hypershard as a CLI tool.
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     // This includes the kotlin runtime in to the fat jar
     implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.6.25'
     implementation 'com.github.cretz.kastree:kastree-ast-psi:0.1.0'
+    implementation 'com.github.ajalt:clikt:2.2.0'
     testImplementation  "junit:junit:4.12"
     testImplementation "org.assertj:assertj-core:3.11.1"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.3.50"
@@ -35,7 +36,7 @@ compileTestKotlin {
 jar {
     // Use the shaded jar instead
     enabled = false
-    dependsOn(shadowJar { classifier = null })
+    dependsOn(shadowJar { archiveClassifier.set(null) })
 
     manifest {
         attributes 'Main-Class': 'com.dropbox.mobile.hypershard.HypershardKt'

--- a/example/run_hypershard.py
+++ b/example/run_hypershard.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
     if not os.path.isfile(file_name):    
         url_opener = urllib.URLopener()
         url_opener.retrieve("https://search.maven.org/remotecontent?filepath=com/dropbox/mobile/hypershard/hypershard/1.0.0/hypershard-1.0.0.jar", file_name)
+
+    # TODO Update after 1.0.1 is uploaded
     hypershard_command = "java -jar hypershard.jar UiTest src/test/resources"
     print "Input: \n", hypershard_command
     output = subprocess.check_output(hypershard_command.split())

--- a/example/run_hypershard.py
+++ b/example/run_hypershard.py
@@ -23,10 +23,9 @@ if __name__ == "__main__":
 
     if not os.path.isfile(file_name):    
         url_opener = urllib.URLopener()
-        url_opener.retrieve("https://search.maven.org/remotecontent?filepath=com/dropbox/mobile/hypershard/hypershard/1.0.0/hypershard-1.0.0.jar", file_name)
+        url_opener.retrieve("https://oss.sonatype.org/service/local/repositories/snapshots/content/com/dropbox/mobile/hypershard/hypershard/1.0.1-SNAPSHOT/hypershard-1.0.1-20191015.055746-1.jar", file_name)
 
-    # TODO Update after 1.0.1 is uploaded
-    hypershard_command = "java -jar hypershard.jar UiTest src/test/resources"
+    hypershard_command = "java -jar hypershard.jar --annotation-name UiTest src/test/resources"
     print "Input: \n", hypershard_command
     output = subprocess.check_output(hypershard_command.split())
     print "Output: \n" , output

--- a/src/main/kotlin/com/dropbox/mobile/hypershard/AnnotationValue.kt
+++ b/src/main/kotlin/com/dropbox/mobile/hypershard/AnnotationValue.kt
@@ -1,0 +1,6 @@
+package com.dropbox.mobile.hypershard
+
+sealed class AnnotationValue {
+    class Present(val annotationName: String) : AnnotationValue()
+    class Empty : AnnotationValue()
+}

--- a/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
+++ b/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
@@ -3,6 +3,11 @@
  */
 package com.dropbox.mobile.hypershard
 
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.option
 import com.github.javaparser.JavaParser
 import com.github.javaparser.ast.CompilationUnit
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
@@ -38,20 +43,18 @@ interface HyperShard {
 /**
  * @see [HyperShard]
  *
- * @property annotationName annotation name at the class level e.g. UiTest (@ not needed)
+ * @property annotationValue annotation name at the class level e.g. UiTest (@ not needed)
  * @property dirs list of directories to parse. Hypershard will walk down from the root.
  */
 class RealHyperShard(
-    private val annotationName: String,
-    private val dirs: Array<String>
+    private val annotationValue: AnnotationValue,
+    private val dirs: List<String>
 ) : HyperShard {
 
     /**
      * @see [HyperShard.gatherTests]
      */
     override fun gatherTests(): List<String> {
-        checkUsage(dirs)
-
         val tests = mutableListOf<String>()
         for (dir in dirs) {
             val projectDir = File(dir)
@@ -125,20 +128,22 @@ class RealHyperShard(
                 val types = cu.types
                 for (type in types) {
                     val classOrInterfaceDeclaration =
-                            type as? ClassOrInterfaceDeclaration ?: continue
-
-                    val annotationUiTest =
-                            classOrInterfaceDeclaration.getAnnotationByName(annotationName)
-                    if (annotationUiTest.isPresent) {
+                        type as? ClassOrInterfaceDeclaration ?: continue
+                    val shouldProcessTestMethod =
+                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue)
+                    if (shouldProcessTestMethod) {
                         val methods = type.methods
                         for (method in methods) {
                             val annotationTest = method.getAnnotationByName("Test")
                             if (annotationTest.isPresent) {
                                 tests.add(
-                                        String.format("%s.%s.%s",
-                                                cu.packageDeclaration.get().name,
-                                                type.name,
-                                                method.name))
+                                    String.format(
+                                        "%s.%s.%s",
+                                        cu.packageDeclaration.get().name,
+                                        type.name,
+                                        method.name
+                                    )
+                                )
                             }
                         }
                     }
@@ -147,6 +152,23 @@ class RealHyperShard(
         }.visit(JavaParser.parse(file), null)
 
         return tests
+    }
+
+    /**
+     * Returns true if we found the class annotation or if's meant to be empty
+     */
+    private fun shouldProcessTestMethods(
+        classOrInterfaceDeclaration: ClassOrInterfaceDeclaration,
+        annotationValue: AnnotationValue
+    ): Boolean {
+        return when (annotationValue) {
+            is AnnotationValue.Present -> {
+                val annotationUiTest =
+                    classOrInterfaceDeclaration.getAnnotationByName(annotationValue.annotationName)
+                annotationUiTest.isPresent
+            }
+            is AnnotationValue.Empty -> true
+        }
     }
 
     /**
@@ -167,14 +189,8 @@ class RealHyperShard(
         for (declaration in allDeclarations) {
             val ktClass = declaration as? KtClass ?: continue
 
-            var uiTestFound = false
-            for (annotationEntry in ktClass.annotationEntries) {
-                if (annotationEntry.shortName.toString() == annotationName) {
-                    uiTestFound = true
-                    break
-                }
-            }
-            if (!uiTestFound) {
+            val shouldProcessTestMethods = shouldProcessTestMethods(ktClass, annotationValue)
+            if (!shouldProcessTestMethods) {
                 continue
             }
 
@@ -202,20 +218,57 @@ class RealHyperShard(
         }
         return tests
     }
+
+    /**
+     * Returns true if we found the class annotation or if's meant to be empty
+     */
+    private fun shouldProcessTestMethods(
+        ktClass: KtClass,
+        annotationValue: AnnotationValue
+    ): Boolean {
+        val shouldProcessTestMethods = when (annotationValue) {
+            is AnnotationValue.Present -> {
+                var found = false
+                for (annotationEntry in ktClass.annotationEntries) {
+                    if (annotationEntry.shortName.toString() == annotationValue.annotationName) {
+                        found = true
+                        break
+                    }
+                }
+                found
+            }
+            is AnnotationValue.Empty -> true
+        }
+        return shouldProcessTestMethods
+    }
+}
+
+class HypershardCommand :
+    CliktCommand(
+        help = "Hypershard is a fast and simple test collector that uses the Kotlin and Java " +
+            "ASTs. Hypershard CLI will print full qualified test names found in dir(s)."
+    ) {
+    val annotationName by option(
+        help = "Class annotation name to process. For example, if this was set to 'UiTest', " +
+            "then Hypershard will only process classes annotated with @UiTest."
+    )
+        .default("")
+    val dirs by argument(
+        name = "dirs", help = "Dir(s) to process. " +
+            "The location of the test classes to parse"
+    )
+        .multiple()
+
+    override fun run() {
+        val annotationValue = when (annotationName) {
+            "" -> AnnotationValue.Empty()
+            else -> AnnotationValue.Present(annotationName)
+        }
+        val hyperShard = RealHyperShard(annotationValue, dirs)
+        hyperShard.gatherTests().stream().forEach(::println)
+    }
 }
 
 fun main(args: Array<String>) {
-    checkUsage(args)
-    val annotationName = args[0]
-    val dirs = args.sliceArray(1 until args.size)
-    val processor = RealHyperShard(annotationName, dirs)
-    processor.gatherTests().stream().forEach(::println)
-}
-
-private fun checkUsage(dirs: Array<String>) {
-    check(dirs.isNotEmpty()) {
-        "Usage: " +
-            "java -jar hypershard-x.y.z-all.jar " +
-            "annotationName dir1 dir2 dir3 ..."
-    }
+    HypershardCommand().main(args)
 }

--- a/src/test/kotlin/com/dropbox/mobile/hypershard/HypershardTest.kt
+++ b/src/test/kotlin/com/dropbox/mobile/hypershard/HypershardTest.kt
@@ -6,68 +6,72 @@ import org.assertj.core.api.Assertions.assertThat
 
 class HypershardTest {
     private val resources = "src/test/resources"
-    private val processor: RealHyperShard
+    private val hypershard: RealHyperShard
     private val files: Set<File>
 
     init {
         val file = File(resources).also { checkNotNull(it.absoluteFile) }
-        processor = RealHyperShard("UiTest", arrayOf(resources))
-        files = processor.getFiles(file, ALLOWED_EXTENSIONS)
+        hypershard = RealHyperShard(AnnotationValue.Present("UiTest"), listOf(resources))
+        files = hypershard.getFiles(file, ALLOWED_EXTENSIONS)
     }
 
     @Test
-    fun getFiles() {
-        assertThat(files.size).isEqualTo(4)
+    fun `GIVEN hypershard WHEN get all files THEN all are found`() {
+        assertThat(files.size).isEqualTo(6)
     }
 
     @Test
-    fun test_GIVEN_files_WHEN_filter_swift_THEN_no_results() {
-        assertThat(processor.filterFiles(".swift", files)).isEmpty()
+    fun `GIVEN files WHEN filter swift THEN no results`() {
+        assertThat(hypershard.filterFiles(".swift", files)).isEmpty()
     }
 
     @Test
-    fun test_GIVEN_files_WHEN_filter_java_THEN_results_found() {
-        assertThat(processor.filterFiles(".java", files).size).isEqualTo(2)
+    fun `GIVEN files WHEN filter java THEN results found`() {
+        assertThat(hypershard.filterFiles(".java", files).size).isEqualTo(3)
     }
 
     @Test
-    fun test_GIVEN_files_WHEN_filter_kt_THEN_results_found() {
-        assertThat(processor.filterFiles(".kt", files).size).isEqualTo(2)
+    fun `GIVEN files WHEN filter kt THEN results found`() {
+        assertThat(hypershard.filterFiles(".kt", files).size).isEqualTo(3)
     }
 
     @Test
-    fun test_GIVEN_files_WHEN_processing_java_then_tests_found() {
+    fun `GIVEN files WHEN processing java UiTest THEN tests found`() {
         val tests = mutableListOf<String>()
         with(tests) {
             addAll(arrayListOf())
         }
-        val javaFiles = processor.filterFiles(".java", files)
+        val javaFiles = hypershard.filterFiles(".java", files)
         for (file in javaFiles) {
-            tests.addAll(processor.collectTestsFromJavaFile(file))
+            tests.addAll(hypershard.collectTestsFromJavaFile(file))
         }
         assertThat(tests.size).`as`("Test cases found does not match expected: $tests").isEqualTo(4)
     }
 
     @Test
-    fun test_GIVEN_files_WHEN_processing_kt_then_tests_found() {
+    fun `GIVEN files WHEN processing kt UiTest THEN tests found`() {
         val tests = mutableListOf<String>()
         with(tests) {
             addAll(arrayListOf())
         }
-        val kotlinFiles = processor.filterFiles(".kt", files)
+        val kotlinFiles = hypershard.filterFiles(".kt", files)
         for (file in kotlinFiles) {
-            tests.addAll(processor.collectTestsFromKotlinFile(file))
+            tests.addAll(hypershard.collectTestsFromKotlinFile(file))
         }
         assertThat(tests.size).`as`("Test cases found does not match expected: $tests").isEqualTo(5)
     }
 
     @Test
-    fun test_GIVEN_tests_WHEN_gathering_all_tests_THEN_tests_found() {
-        val tests = processor.gatherTests()
+    fun `GIVEN tests WHEN gathering all UiTest THEN tests found`() {
+        val tests = hypershard.gatherTests()
         assertThat(tests.size).`as`("Test cases found does not match expected: $tests").isEqualTo(9)
+    }
 
-        for (test in tests) {
-            assertThat(test).doesNotContain("#")
-        }
+    @Test
+    fun `GIVEN tests WHEN gathering all tests THEN tests found`() {
+        val hypershard = RealHyperShard(AnnotationValue.Empty(), listOf(resources))
+        val tests = hypershard.gatherTests()
+        assertThat(tests.size).`as`("Test cases found does not match expected: $tests")
+            .isEqualTo(13)
     }
 }

--- a/src/test/resources/com/dropbox/android/java/FakeClassTest.java
+++ b/src/test/resources/com/dropbox/android/java/FakeClassTest.java
@@ -13,10 +13,8 @@ import org.junit.runner.RunWith;
 /**
  * A deliberately ignored class with a few tests inside
  */
-@UiTest
-@Ignore
 @RunWith(AndroidJUnit4.class)
-public class FakeIgnoredClassTest {
+public class FakeIgnoredClassUiTest {
     /**
      * lint needs a javadoc comment
      */

--- a/src/test/resources/com/dropbox/android/java/FakeIgnoredClassUiTest.java
+++ b/src/test/resources/com/dropbox/android/java/FakeIgnoredClassUiTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, Dropbox, Inc. All rights reserved.
+ */
+
+package com.dropbox.android.java;
+
+import android.support.test.runner.AndroidJUnit4;
+import com.dropbox.core.test.ui_runner.annotations.UiTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A deliberately ignored class with a few tests inside
+ */
+@UiTest
+@Ignore
+@RunWith(AndroidJUnit4.class)
+public class FakeIgnoredClassUiTest {
+    /**
+     * lint needs a javadoc comment
+     */
+    @Test
+    public void emptyTest1() {}
+
+    /**
+     * lint needs a javadoc comment
+     */
+    @Test
+    public void emptyTest2() {}
+}

--- a/src/test/resources/com/dropbox/android/java/FakeIgnoredMethodUiTest.java
+++ b/src/test/resources/com/dropbox/android/java/FakeIgnoredMethodUiTest.java
@@ -11,11 +11,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * A class with ignored methods, parser should find 1 valid test
+ * A class with ignored methods, parser should find 2 valid tests
  */
 @UiTest
 @RunWith(AndroidJUnit4.class)
-public class FakeIgnoredMethodTest {
+public class FakeIgnoredMethodUiTest {
     /**
      * lint needs a javadoc comment
      */

--- a/src/test/resources/com/dropbox/android/kotlin/FakeClassTest.kt
+++ b/src/test/resources/com/dropbox/android/kotlin/FakeClassTest.kt
@@ -6,18 +6,14 @@ package com.dropbox.android.kotlin
 
 import android.support.test.runner.AndroidJUnit4
 import com.dropbox.core.test.ui_runner.annotations.UiTest
-import jdk.nashorn.internal.ir.annotations.Ignore
-import kotlin.test.Test
-import org.junit.Ignore
+import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
  * A deliberately ignored class with a few tests inside
  */
-@UiTest
-@Ignore
 @RunWith(AndroidJUnit4::class)
-class FakeIgnoredClassTest {
+class FakeClassTest {
     /**
      * lint needs a javadoc comment
      */

--- a/src/test/resources/com/dropbox/android/kotlin/FakeIgnoredClassUiTest.kt
+++ b/src/test/resources/com/dropbox/android/kotlin/FakeIgnoredClassUiTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, Dropbox, Inc. All rights reserved.
+ */
+
+package com.dropbox.android.kotlin
+
+import android.support.test.runner.AndroidJUnit4
+import com.dropbox.core.test.ui_runner.annotations.UiTest
+import kotlin.test.Test
+import org.junit.Ignore
+import org.junit.runner.RunWith
+
+/**
+ * A deliberately ignored class with a few tests inside
+ */
+@UiTest
+@Ignore
+@RunWith(AndroidJUnit4::class)
+class FakeIgnoredClassUiTest {
+    /**
+     * lint needs a javadoc comment
+     */
+    @Test
+    fun emptyTest1() {
+    }
+
+    /**
+     * lint needs a javadoc comment
+     */
+    @Test
+    fun emptyTest2() {
+    }
+}

--- a/src/test/resources/com/dropbox/android/kotlin/FakeIgnoredMethodUiTest.kt
+++ b/src/test/resources/com/dropbox/android/kotlin/FakeIgnoredMethodUiTest.kt
@@ -6,17 +6,16 @@ package com.dropbox.android.kotlin
 
 import android.support.test.runner.AndroidJUnit4
 import com.dropbox.core.test.ui_runner.annotations.UiTest
-import jdk.nashorn.internal.ir.annotations.Ignore
 import kotlin.test.Test
 import org.junit.Ignore
 import org.junit.runner.RunWith
 
 /**
- * A class with ignored methods, parser should find 1 valid test
+ * A class with ignored methods, parser should find 3 valid tests
  */
 @UiTest
 @RunWith(AndroidJUnit4::class)
-class FakeIgnoredMethodTest {
+class FakeIgnoredMethodUiTest {
     /**
      * lint needs a javadoc comment
      */


### PR DESCRIPTION
Currently, Hypershard will only process class files that are annotated. This change will allow Hypershard to process any classes with test methods.

Also, adds a more robust CLI system by using https://github.com/ajalt/clikt/