### PR TITLE
Remove matrix from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
-language: minimal
+language: java
+dist: trusty
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+script:
+  - "./gradlew clean check test --stacktrace"
 
-matrix:
-  include:
-    - language: java
-      dist: trusty
-      before_cache:
-        - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-        - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-      cache:
-        directories:
-          - $HOME/.gradle/caches/
-          - $HOME/.gradle/wrapper/
-      script:
-        - "./gradlew clean check test --stacktrace"
-
-      notifications:
-        email: false
+notifications:
+  email: false


### PR DESCRIPTION
Initially, we were planning on putting iOS and Android Hypershard in the same Github project. Now that they are their own projects, no need for a matrix, so let's simplify the Travis config file.