### PR TITLE
Fix a typo in the python sample

### DIFF
--- a/example/run_hypershard.py
+++ b/example/run_hypershard.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
     Shows usage of Hypershard as a CLI tool
 
     Input:
-        java -jar hypershard.jar UiTest src/test/resources
+        java -jar hypershard.jar --annotation-name UiTest src/test/resources
     Output:
         com.dropbox.android.java.FakeIgnoredClassTest.emptyTest1
         com.dropbox.android.java.FakeIgnoredClassTest.emptyTest2


### PR DESCRIPTION
The sample was missing the `--annotation-name` flag when showing the usage. 