### PR TITLE
Add ability to specify class annotations to filter

### DIFF
--- a/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
+++ b/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
@@ -246,8 +246,10 @@ class RealHyperShard(
         return hasAnnotationValue && !hasNotAnnotationValue
     }
 
-    private fun hasAnnotation(classOrInterfaceDeclaration: ClassOrInterfaceDeclaration,
-        annotationValue: ClassAnnotationValue.Present): Boolean {
+    private fun hasAnnotation(
+        classOrInterfaceDeclaration: ClassOrInterfaceDeclaration,
+        annotationValue: ClassAnnotationValue.Present
+    ): Boolean {
         val annotationUiTest =
             classOrInterfaceDeclaration.getAnnotationByName(annotationValue.annotationName)
         return annotationUiTest.isPresent
@@ -370,7 +372,10 @@ class RealHyperShard(
         return hasAnnotationValue && !hasNotAnnotationValue
     }
 
-    private fun hasAnnotation(ktClass: KtClass, annotationValue: ClassAnnotationValue.Present): Boolean {
+    private fun hasAnnotation(
+        ktClass: KtClass,
+        annotationValue: ClassAnnotationValue.Present
+    ): Boolean {
         for (annotationEntry in ktClass.annotationEntries) {
             if (annotationEntry.shortName.toString() == annotationValue.annotationName) {
                 return true
@@ -394,8 +399,8 @@ class HypershardCommand :
     )
         .default("")
     val notAnnotationName by option(
-        help = "Class annotation name *not* to process. For example, if this was set to 'UiTest', " +
-            "then Hypershard will *not* process classes annotated with @UiTest."
+        help = "Class annotation name *not* to process. For example, if this was set to 'UiTest'," +
+            " then Hypershard will *not* process classes annotated with @UiTest."
     )
         .default("")
     val dirs by argument(

--- a/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
+++ b/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
@@ -55,6 +55,7 @@ interface HyperShard {
  */
 class RealHyperShard(
     private val annotationValue: ClassAnnotationValue,
+    private val notAnnotationValue: ClassAnnotationValue,
     private val dirs: List<String>
 ) : HyperShard {
 
@@ -155,7 +156,8 @@ class RealHyperShard(
                     val classOrInterfaceDeclaration =
                         type as? ClassOrInterfaceDeclaration ?: continue
                     val shouldProcessTestMethod =
-                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue)
+                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue,
+                            notAnnotationValue)
                     if (shouldProcessTestMethod) {
                         val methods = type.methods
                         for (method in methods) {
@@ -179,7 +181,7 @@ class RealHyperShard(
      *
      * @param file a .java file
      */
-    internal fun isJavaTest(file: File): Boolean {
+    private fun isJavaTest(file: File): Boolean {
         checkIsJava(file)
 
         var isTest = false
@@ -194,7 +196,8 @@ class RealHyperShard(
                     val classOrInterfaceDeclaration =
                         type as? ClassOrInterfaceDeclaration ?: continue
                     val shouldProcessTestMethod =
-                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue)
+                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue,
+                            notAnnotationValue)
                     if (shouldProcessTestMethod) {
                         val methods = type.methods
                         for (method in methods) {
@@ -223,16 +226,31 @@ class RealHyperShard(
      */
     private fun shouldProcessTestMethods(
         classOrInterfaceDeclaration: ClassOrInterfaceDeclaration,
-        annotationValue: ClassAnnotationValue
+        annotationValue: ClassAnnotationValue,
+        notAnnotationValue: ClassAnnotationValue
     ): Boolean {
-        return when (annotationValue) {
+        val hasAnnotationValue = when (annotationValue) {
             is ClassAnnotationValue.Present -> {
-                val annotationUiTest =
-                    classOrInterfaceDeclaration.getAnnotationByName(annotationValue.annotationName)
-                annotationUiTest.isPresent
+                hasAnnotation(classOrInterfaceDeclaration, annotationValue)
             }
             is ClassAnnotationValue.Empty -> true
         }
+
+        val hasNotAnnotationValue = when (notAnnotationValue) {
+            is ClassAnnotationValue.Present -> {
+                hasAnnotation(classOrInterfaceDeclaration, notAnnotationValue)
+            }
+            is ClassAnnotationValue.Empty -> false
+        }
+
+        return hasAnnotationValue && !hasNotAnnotationValue
+    }
+
+    private fun hasAnnotation(classOrInterfaceDeclaration: ClassOrInterfaceDeclaration,
+        annotationValue: ClassAnnotationValue.Present): Boolean {
+        val annotationUiTest =
+            classOrInterfaceDeclaration.getAnnotationByName(annotationValue.annotationName)
+        return annotationUiTest.isPresent
     }
 
     /**
@@ -251,7 +269,8 @@ class RealHyperShard(
         for (declaration in allDeclarations) {
             val ktClass = declaration as? KtClass ?: continue
 
-            val shouldProcessTestMethods = shouldProcessTestMethods(ktClass, annotationValue)
+            val shouldProcessTestMethods = shouldProcessTestMethods(ktClass, annotationValue,
+                notAnnotationValue)
             if (!shouldProcessTestMethods) {
                 continue
             }
@@ -296,7 +315,8 @@ class RealHyperShard(
         for (declaration in allDeclarations) {
             val ktClass = declaration as? KtClass ?: continue
 
-            val shouldProcessTestMethods = shouldProcessTestMethods(ktClass, annotationValue)
+            val shouldProcessTestMethods = shouldProcessTestMethods(ktClass, annotationValue,
+                notAnnotationValue)
             if (!shouldProcessTestMethods) {
                 continue
             }
@@ -331,19 +351,32 @@ class RealHyperShard(
      */
     private fun shouldProcessTestMethods(
         ktClass: KtClass,
-        annotationValue: ClassAnnotationValue
+        annotationValue: ClassAnnotationValue,
+        notAnnotationValue: ClassAnnotationValue
     ): Boolean {
-        return when (annotationValue) {
+        val hasAnnotationValue = when (annotationValue) {
             is ClassAnnotationValue.Present -> {
-                for (annotationEntry in ktClass.annotationEntries) {
-                    if (annotationEntry.shortName.toString() == annotationValue.annotationName) {
-                        return true
-                    }
-                }
-                return false
+                hasAnnotation(ktClass, annotationValue)
             }
             is ClassAnnotationValue.Empty -> true
         }
+
+        val hasNotAnnotationValue = when (notAnnotationValue) {
+            is ClassAnnotationValue.Present -> {
+                hasAnnotation(ktClass, notAnnotationValue)
+            }
+            is ClassAnnotationValue.Empty -> false
+        }
+        return hasAnnotationValue && !hasNotAnnotationValue
+    }
+
+    private fun hasAnnotation(ktClass: KtClass, annotationValue: ClassAnnotationValue.Present): Boolean {
+        for (annotationEntry in ktClass.annotationEntries) {
+            if (annotationEntry.shortName.toString() == annotationValue.annotationName) {
+                return true
+            }
+        }
+        return false
     }
 }
 
@@ -360,6 +393,11 @@ class HypershardCommand :
             "then Hypershard will only process classes annotated with @UiTest."
     )
         .default("")
+    val notAnnotationName by option(
+        help = "Class annotation name *not* to process. For example, if this was set to 'UiTest', " +
+            "then Hypershard will *not* process classes annotated with @UiTest."
+    )
+        .default("")
     val dirs by argument(
         name = "dirs", help = "Dir(s) to process. " +
             "The location of the test classes to parse"
@@ -371,7 +409,11 @@ class HypershardCommand :
             "" -> ClassAnnotationValue.Empty
             else -> ClassAnnotationValue.Present(annotationName)
         }
-        val hyperShard = RealHyperShard(annotationValue, dirs)
+        val notAnnotationValue = when (notAnnotationName) {
+            "" -> ClassAnnotationValue.Empty
+            else -> ClassAnnotationValue.Present(notAnnotationName)
+        }
+        val hyperShard = RealHyperShard(annotationValue, notAnnotationValue, dirs)
         hyperShard.gatherTests().forEach(::println)
     }
 }

--- a/src/test/kotlin/com/dropbox/mobile/hypershard/HypershardTest.kt
+++ b/src/test/kotlin/com/dropbox/mobile/hypershard/HypershardTest.kt
@@ -33,19 +33,24 @@ class HypershardTest {
             "com.dropbox.android.kotlin.FakeClassTest.emptyTest2"
         )
         private val allTests = expectedUiTests + expectedNonUiTests
-        private val allTestFiles = listOf(
-            File("src/test/resources/com/dropbox/android/java/FakeIgnoredMethodUiTest.java"),
+
+        private val nonUiTestFiles = listOf(
             File("src/test/resources/com/dropbox/android/java/FakeClassTest.java"),
+            File("src/test/resources/com/dropbox/android/kotlin/FakeClassTest.kt")
+        )
+        private val uiTestFiles = listOf(
+            File("src/test/resources/com/dropbox/android/java/FakeIgnoredMethodUiTest.java"),
             File("src/test/resources/com/dropbox/android/java/FakeIgnoredClassUiTest.java"),
-            File("src/test/resources/com/dropbox/android/kotlin/FakeClassTest.kt"),
             File("src/test/resources/com/dropbox/android/kotlin/FakeIgnoredClassUiTest.kt"),
             File("src/test/resources/com/dropbox/android/kotlin/FakeIgnoredMethodUiTest.kt")
         )
+        private val allTestFiles = nonUiTestFiles + uiTestFiles
     }
 
     init {
         val file = File(resources).also { checkNotNull(it.absoluteFile) }
-        hypershard = RealHyperShard(ClassAnnotationValue.Present("UiTest"), listOf(resources))
+        hypershard = RealHyperShard(ClassAnnotationValue.Present("UiTest"),
+            ClassAnnotationValue.Empty, listOf(resources))
         files = hypershard.getFiles(file, ALLOWED_EXTENSIONS)
     }
 
@@ -106,7 +111,8 @@ class HypershardTest {
 
     @Test
     fun `GIVEN tests WHEN gathering all tests THEN tests found`() {
-        val hypershard = RealHyperShard(ClassAnnotationValue.Empty, listOf(resources))
+        val hypershard = RealHyperShard(ClassAnnotationValue.Empty, ClassAnnotationValue.Empty,
+            listOf(resources))
         val tests = hypershard.gatherTests()
         assertThat(tests.size).isEqualTo(13)
         assertThat(tests).containsExactlyElementsIn(allTests)
@@ -114,9 +120,46 @@ class HypershardTest {
 
     @Test
     fun `GIVEN tests WHEN gathering all test files THEN tests files found`() {
-        val hypershard = RealHyperShard(ClassAnnotationValue.Empty, listOf(resources))
+        val hypershard = RealHyperShard(ClassAnnotationValue.Empty, ClassAnnotationValue.Empty,
+            listOf(resources))
         val tests = hypershard.gatherTestFiles()
         assertThat(tests.size).isEqualTo(6)
         assertThat(tests).containsExactlyElementsIn(allTestFiles)
+    }
+
+    @Test
+    fun `GIVEN tests WHEN gathering not UiTests THEN non ui test files found`() {
+        val hypershard = RealHyperShard(ClassAnnotationValue.Empty,
+            ClassAnnotationValue.Present("UiTest"),
+            listOf(resources))
+        val tests = hypershard.gatherTestFiles()
+        assertThat(tests).containsExactlyElementsIn(nonUiTestFiles)
+    }
+
+    @Test
+    fun `GIVEN tests WHEN gathering not UiTests THEN non ui tests found`() {
+        val hypershard = RealHyperShard(ClassAnnotationValue.Empty,
+            ClassAnnotationValue.Present("UiTest"),
+            listOf(resources))
+        val tests = hypershard.gatherTests()
+        assertThat(tests).isEqualTo(expectedNonUiTests)
+    }
+
+    @Test
+    fun `GIVEN tests WHEN gathering not UiTest and UiTest THEN no tests files found`() {
+        val hypershard = RealHyperShard(ClassAnnotationValue.Present("UiTest"),
+            ClassAnnotationValue.Present("UiTest"),
+            listOf(resources))
+        val tests = hypershard.gatherTestFiles()
+        assertThat(tests).isEmpty()
+    }
+
+    @Test
+    fun `GIVEN tests WHEN gathering not UiTests and UiTest THEN no tests found`() {
+        val hypershard = RealHyperShard(ClassAnnotationValue.Present("UiTest"),
+            ClassAnnotationValue.Present("UiTest"),
+            listOf(resources))
+        val tests = hypershard.gatherTests()
+        assertThat(tests).isEmpty()
     }
 }


### PR DESCRIPTION
This adds a `--notAnnotationName` argument to exclude test classes which are annotated with something.  If the user specifies both an `--annotationName UiTest` and `--notAnnotationName Ignore`, the class will need to have `@UiTest`, and not have `@Ignore`

Open to any suggestions, thanks! 