### PR TITLE
v1.1.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Change Log
+## Version 1.1.2 (2020-12-02)
+- Added `-notAnnotation` parameter to ignore classes with an annotation
+
 ## Version 1.1.1 (2019-10-28)
 - Added method to Hypershard to return a list of files with tests
 - Split the jar from the shaded jar

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Snapshots of the development version are available in [Sonatype's `snapshots` re
 Another use case could be to use Hypershard as a dependency in your project
 
 ```groovy
-implementation 'com.dropbox.mobile.hypershard:hypershard:1.1.1'
+implementation 'com.dropbox.mobile.hypershard:hypershard:1.1.2'
 ```
 
 
 # Usage
 ```
-java -jar hypershard-1.1.1-all.jar --help
+java -jar hypershard-1.1.2-all.jar --help
 ```
 
 Here's an [example Python script](example/run_hypershard.py) that uses Hypershard as a CLI tool.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ Releasing
  4. Update [example/run_hypershard.py](example/run_hypershard.py) as needed.
  5. `git commit -am "Prepare for release X.Y.Z."` (where X.Y.Z is the new version)
  6. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
- 7. `./gradlew clean uploadArchives`
+ 7. `./gradlew clean uploadArchives -PSONATYPE_NEXUS_USERNAME=<username> -PSONATYPE_NEXUS_PASSWORD=<password> --no-daemon --no-parallel`
  8. Update the `gradle.properties` to the next SNAPSHOT version.
  9. `git commit -am "Prepare next development version."`
  10. `git push && git push --tags`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.dropbox.mobile.hypershard
-VERSION_NAME=1.1.2
+VERSION_NAME=1.1.3-SNAPSHOT
 POM_DESCRIPTION=CLI tool for collecting tests
 POM_URL=https://github.com/dropbox/hypershard
 POM_SCM_URL=https://github.com/dropbox/hypershard

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 GROUP=com.dropbox.mobile.hypershard
 VERSION_NAME=1.1.2
+POM_DESCRIPTION=CLI tool for collecting tests
 POM_URL=https://github.com/dropbox/hypershard
 POM_SCM_URL=https://github.com/dropbox/hypershard
 POM_SCM_CONNECTION=scm:git:https://github.com/dropbox/hypershard

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.dropbox.mobile.hypershard
-VERSION_NAME=1.1.2-SNAPSHOT
+VERSION_NAME=1.1.2
 POM_URL=https://github.com/dropbox/hypershard
 POM_SCM_URL=https://github.com/dropbox/hypershard
 POM_SCM_CONNECTION=scm:git:https://github.com/dropbox/hypershard


### PR DESCRIPTION
Release is available via maven central - https://oss.sonatype.org/service/local/repositories/releases/content/com/dropbox/mobile/hypershard/hypershard/1.1.2/

