### PR TITLE
Update all dependencies and minimize shaded jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,15 @@
 plugins {
-    id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.20'
-    id 'com.github.johnrengelman.shadow' version '5.2.0'
+    id "java"
+    id "org.jetbrains.kotlin.jvm" version "1.6.20"
+    id "com.github.johnrengelman.shadow" version "7.1.2"
     id "com.vanniktech.maven.publish" version "0.19.0"
-    id "org.jlleitschuh.gradle.ktlint" version "9.2.1"
+    id "org.jlleitschuh.gradle.ktlint" version "10.2.1"
+    id "com.github.ben-manes.versions" version "0.42.0"
 }
 
 repositories {
-    maven { url 'https://jitpack.io' }
     mavenCentral()
     google()
-    jcenter()
 }
 
 ktlint {
@@ -19,17 +18,17 @@ ktlint {
 
 dependencies {
     // This includes the kotlin runtime in to the fat jar
-    implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.6.25'
-    implementation "com.github.ajalt.clikt:clikt:3.2.0"
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.20"
+    implementation "com.github.javaparser:javaparser-symbol-solver-core:3.24.2"
+    implementation "com.github.ajalt.clikt:clikt:3.4.1"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+    implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:1.6.20"
 
-    testImplementation  "junit:junit:4.13"
-    testImplementation "com.google.truth:truth:1.0.1"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.4.20"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:1.4.20"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-common:1.4.20"
-    testImplementation "org.jetbrains.kotlin:kotlin-test:1.4.20"
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.truth:truth:1.1.3"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:1.6.20"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:1.6.20"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-common:1.6.20"
+    testImplementation "org.jetbrains.kotlin:kotlin-test:1.6.20"
 
     // Source: https://github.com/kotlinx/ast
     // This includes the compiled libraries for 
@@ -44,33 +43,28 @@ dependencies {
 }
 
 compileKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
 }
 
 test {
     // This is required for an issue integrating Kotlin with newer JVMs:
     // https://youtrack.jetbrains.com/issue/IDEA-248785
-    jvmArgs '--illegal-access=permit'
+    jvmArgs "--illegal-access=permit"
 }
 
 jar {
     dependsOn(shadowJar)
 
     manifest {
-        attributes 'Main-Class': 'com.dropbox.mobile.hypershard.HypershardKt'
+        attributes "Main-Class": "com.dropbox.mobile.hypershard.HypershardKt"
     }
 }
 
 shadowJar {
-    classifier = "all"
-}
-
-artifacts {
-    runtime shadowJar
-    archives shadowJar
+    minimize()
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Wed Oct 16 23:45:35 PDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'hypershard'
+rootProject.name = "hypershard"

--- a/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
+++ b/src/main/kotlin/com/dropbox/mobile/hypershard/Hypershard.kt
@@ -55,7 +55,8 @@ interface HyperShard {
 class RealHyperShard(
     private val annotationValue: ClassAnnotationValue,
     private val notAnnotationValue: ClassAnnotationValue,
-    private val dirs: List<String>
+    private val dirs: List<String>,
+    private val javaParser: JavaParser = JavaParser()
 ) : HyperShard {
 
     /**
@@ -155,22 +156,25 @@ class RealHyperShard(
                     val classOrInterfaceDeclaration =
                         type as? ClassOrInterfaceDeclaration ?: continue
                     val shouldProcessTestMethod =
-                        shouldProcessTestMethods(classOrInterfaceDeclaration, annotationValue,
-                            notAnnotationValue)
+                        shouldProcessTestMethods(
+                            classOrInterfaceDeclaration, annotationValue,
+                            notAnnotationValue
+                        )
                     if (shouldProcessTestMethod) {
                         val methods = type.methods
                         for (method in methods) {
                             val annotationTest = method.getAnnotationByName("Test")
                             if (annotationTest.isPresent) {
-                                tests.add("${cu.packageDeclaration.get().name}." +
-                                    "${type.name}.${method.name}"
+                                tests.add(
+                                    "${cu.packageDeclaration.get().name}." +
+                                        "${type.name}.${method.name}"
                                 )
                             }
                         }
                     }
                 }
             }
-        }.visit(JavaParser.parse(file), null)
+        }.visit(javaParser.parse(file).result.orElseThrow(), null)
 
         return tests
     }
@@ -209,7 +213,7 @@ class RealHyperShard(
                     }
                 }
             }
-        }.visit(JavaParser.parse(file), null)
+        }.visit(javaParser.parse(file).result.orElseThrow(), null)
 
         return isTest
     }


### PR DESCRIPTION
Updates all the dependencies to the latest except Ktlint because it enforces different lint checks.

Also now minimizing the shadow jar reducing the final size by 33%

fixes #17